### PR TITLE
Delete includes/os/cachyos.ini

### DIFF
--- a/includes/os/cachyos.ini
+++ b/includes/os/cachyos.ini
@@ -1,8 +1,0 @@
-[cachyos]
-distro = CachyOS
-listvers = 3
-location = cachyos/ISO/*/*/cachyos-*-linux-*.iso
-pattern = (desktop|handheld)/([0-9]+)/cachyos-([a-z]+)-linux-([0-9]+)\.iso
-version = $2
-platform = x86_64
-type = $1


### PR DESCRIPTION
Disabled due to compliance issue: https://wiki.cachyos.org/policy/repository_policy/